### PR TITLE
Add new feature that allows registering Actors externally

### DIFF
--- a/Source/ActorIO/Private/ActorIO.cpp
+++ b/Source/ActorIO/Private/ActorIO.cpp
@@ -117,6 +117,8 @@ FActorIOEventList IActorIO::GetEventsForObject(AActor* InObject)
         if (IOSubsystem)
         {
             IOSubsystem->GetNativeEventsForObject(InObject, OutEvents);
+
+            IOSubsystem->GetObjectEventsFromIORegisters(InObject, OutEvents);
         }
     }
 
@@ -147,6 +149,8 @@ FActorIOFunctionList IActorIO::GetFunctionsForObject(AActor* InObject)
         if (IOSubsystem)
         {
             IOSubsystem->GetNativeFunctionsForObject(InObject, OutFunctions);
+
+            IOSubsystem->GetObjectFunctionsFromIORegisters(InObject, OutFunctions);
         }
     }
 

--- a/Source/ActorIO/Private/ActorIORegisterBase.cpp
+++ b/Source/ActorIO/Private/ActorIORegisterBase.cpp
@@ -1,0 +1,38 @@
+﻿// Copyright Lim Young.
+
+
+#include "ActorIORegisterBase.h"
+
+#include "ActorIOLibrary.h"
+
+void UActorIORegisterBase::RegisterIOEvents_Implementation(AActor* RegisteredActor, FActorIOEventList& EventRegistry)
+{
+}
+
+void UActorIORegisterBase::RegisterIOFunctions_Implementation(AActor* RegisteredActor,
+                                                              FActorIOFunctionList& FunctionRegistry)
+{
+}
+
+TSubclassOf<AActor> UActorIORegisterBase::GetActorsClassRequiredToRegister_Implementation() const
+{
+	return AActor::StaticClass();
+}
+
+void UActorIORegisterBase::BP_RegisterIOEventForRequiredActor(AActor* RegisteredActor, FActorIOEventList& Registry,
+                                                              FName EventId, const FText& DisplayNameText,
+                                                              const FText& TooltipText, FName EventDispatcherName,
+                                                              FName EventProcessorName)
+{
+	UActorIOLibrary::K2_RegisterIOEvent(RegisteredActor, Registry, EventId, DisplayNameText, TooltipText,
+	                                    EventDispatcherName, EventProcessorName);
+}
+
+void UActorIORegisterBase::BP_RegisterIOFunctionForRequiredActor(AActor* RegisteredActor,
+                                                                 FActorIOFunctionList& Registry, FName FunctionId,
+                                                                 const FText& DisplayNameText, const FText& TooltipText,
+                                                                 FString FunctionToExec, FName SubobjectName)
+{
+	UActorIOLibrary::K2_RegisterIOFunction(RegisteredActor, Registry, FunctionId, DisplayNameText, TooltipText,
+	                                       FunctionToExec, SubobjectName);
+}

--- a/Source/ActorIO/Private/ActorIOSubsystemBase.cpp
+++ b/Source/ActorIO/Private/ActorIOSubsystemBase.cpp
@@ -505,6 +505,42 @@ void UActorIOSubsystemBase::GetGlobalNamedArguments(FActionExecutionContext& Exe
     K2_GetGlobalNamedArguments();
 }
 
+void UActorIOSubsystemBase::GetObjectEventsFromIORegisters(AActor* InObject, FActorIOEventList& EventRegistry)
+{
+    for (TSubclassOf<UActorIORegisterBase> Register : ActorIORegisters)
+    {
+        if (!IsValid(Register))
+        {
+            continue;
+        }
+
+        UActorIORegisterBase* RegisterCDO = Register->GetDefaultObject<UActorIORegisterBase>();
+
+        if (InObject->IsA(RegisterCDO->GetActorsClassRequiredToRegister()))
+        {
+            RegisterCDO->RegisterIOEvents(InObject, EventRegistry);
+        }
+    }
+}
+
+void UActorIOSubsystemBase::GetObjectFunctionsFromIORegisters(AActor* InObject, FActorIOFunctionList& FunctionRegistry)
+{
+    for (TSubclassOf<UActorIORegisterBase> Register : ActorIORegisters)
+    {
+        if (!IsValid(Register))
+        {
+            continue;
+        }
+
+        UActorIORegisterBase* RegisterCDO = Register->GetDefaultObject<UActorIORegisterBase>();
+
+        if (InObject->IsA(RegisterCDO->GetActorsClassRequiredToRegister()))
+        {
+            RegisterCDO->RegisterIOFunctions(InObject, FunctionRegistry);
+        }
+    }
+}
+
 void UActorIOSubsystemBase::ProcessEvent_OnActorOverlap(AActor* OverlappedActor, AActor* OtherActor)
 {
     ActionExecContext.SetNamedArgument(TEXT("$Actor"), IsValid(OtherActor) ? OtherActor->GetPathName() : FString());
@@ -513,6 +549,12 @@ void UActorIOSubsystemBase::ProcessEvent_OnActorOverlap(AActor* OverlappedActor,
 void UActorIOSubsystemBase::ProcessEvent_OnActorDestroyed(AActor* DestroyedActor)
 {
     ActionExecContext.SetNamedArgument(TEXT("$Actor"), IsValid(DestroyedActor) ? DestroyedActor->GetPathName() : FString());
+}
+
+void UActorIOSubsystemBase::PostInitialize()
+{
+    const UActorIOSettings* IOSettings = UActorIOSettings::Get();
+    ActorIORegisters = IOSettings->ActorIORegisters;
 }
 
 bool UActorIOSubsystemBase::ShouldCreateSubsystem(UObject* Outer) const

--- a/Source/ActorIO/Public/ActorIORegisterBase.h
+++ b/Source/ActorIO/Public/ActorIORegisterBase.h
@@ -1,0 +1,79 @@
+﻿// Copyright Lim Young.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ActorIO.h"
+#include "UObject/Object.h"
+#include "ActorIORegisterBase.generated.h"
+
+/**
+ * Base class for registering I/O events and functions for an actor.
+ */
+UCLASS(Abstract, Blueprintable, BlueprintType)
+class ACTORIO_API UActorIORegisterBase : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Called when building list of registered I/O events for the actor.
+	 * This function is called every time the list of registered events is requested for the actor.
+	 * Called in editor and at runtime!
+	 */
+	UFUNCTION(BlueprintNativeEvent, Category = "ActorIO|Register")
+	void RegisterIOEvents(AActor* RegisteredActor, FActorIOEventList& EventRegistry);
+
+	/**
+	 * Called when building list of registered I/O functions for the actor.
+	 * This function is called every time the list of registered functions is requested for the actor.
+	 * Called in editor and at runtime!
+	 */
+	UFUNCTION(BlueprintNativeEvent, Category = "ActorIO|Register")
+	void RegisterIOFunctions(AActor* RegisteredActor, FActorIOFunctionList& FunctionRegistry);
+
+	/** Returns the class of actors that are required to register I/O events. */
+	UFUNCTION(BlueprintNativeEvent, Category = "ActorIO|Register")
+	TSubclassOf<AActor> GetActorsClassRequiredToRegister() const;
+
+protected:
+	/**
+	 * Add a new I/O event to the actor's event list.
+	 * Use this to expose a blueprint event dispatcher to the I/O system.
+	 * Should only be called with UActorIORegisterBase derived classes.
+	 *
+	 * @param RegisteredActor The actor we are registering the event for.
+	 * @param Registry The list of I/O events we are adding to.
+	 * @param EventId Unique id of the event. Recommended format is ClassName::EventName.
+	 * @param DisplayNameText Display name to use in the editor for this event.
+	 * @param TooltipText Tooltip to use in the editor for this event.
+	 * @param EventDispatcherName Name of the event dispatcher that should be exposed.
+	 * @param EventProcessorName Name of a function that should be called when firing this event. Use this to handle named arguments (params) for this event.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ActorIO|Register",
+		meta = (DisplayName = "Register I/O Event For Required Actor"))
+	void BP_RegisterIOEventForRequiredActor(AActor* RegisteredActor, UPARAM(Ref)
+	                                        FActorIOEventList& Registry, FName EventId, const FText& DisplayNameText,
+	                                        const FText& TooltipText, FName EventDispatcherName,
+	                                        FName EventProcessorName);
+
+	/**
+	 * Add a new I/O function to the actor's function list.
+	 * Use this to expose a blueprint function to the I/O system.
+	 * Should only be called with UActorIORegisterBase derived classes.
+	 *
+	 * @param RegisteredActor The actor we are registering the function for.
+	 * @param Registry The list of I/O functions we are adding to.
+	 * @param FunctionId Unique id of the function. Recommended format is ClassName::FunctionName.
+	 * @param DisplayNameText Display name to use in the editor for this function.
+	 * @param TooltipText Tooltip to use in the editor for this function.
+	 * @param FunctionToExec Name of the blueprint function that should be exposed.
+	 * @param SubobjectName Specific subobject to call the function on instead of the actor itself.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ActorIO|Register",
+		meta = (DisplayName = "Register I/O Function For Required Actor"))
+	void BP_RegisterIOFunctionForRequiredActor(AActor* RegisteredActor, UPARAM(Ref)
+	                                           FActorIOFunctionList& Registry, FName FunctionId,
+	                                           const FText& DisplayNameText, const FText& TooltipText,
+	                                           FString FunctionToExec, FName SubobjectName);
+};

--- a/Source/ActorIO/Public/ActorIOSettings.h
+++ b/Source/ActorIO/Public/ActorIOSettings.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ActorIO.h"
+#include "ActorIORegisterBase.h"
 #include "Engine/DeveloperSettings.h"
 #include "Templates/SubclassOf.h"
 #include "ActorIOSettings.generated.h"
@@ -35,6 +36,9 @@ public:
 	 */
 	UPROPERTY(Config, NoClear, EditAnywhere, Category = "Settings", DisplayName = "Actor I/O Subsystem Class")
 	TSubclassOf<class UActorIOSubsystemBase> ActorIOSubsystemClass;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Settings")
+	TArray<TSubclassOf<UActorIORegisterBase>> ActorIORegisters;
 
 public:
 

--- a/Source/ActorIO/Public/ActorIOSubsystemBase.h
+++ b/Source/ActorIO/Public/ActorIOSubsystemBase.h
@@ -6,6 +6,7 @@
 #include "Subsystems/WorldSubsystem.h"
 #include "ActorIOSubsystemBase.generated.h"
 
+class UActorIORegisterBase;
 class UActorIOAction;
 
 /**
@@ -21,6 +22,10 @@ public:
 
 	/** Default constructor. */
 	UActorIOSubsystemBase();
+
+protected:
+	UPROPERTY()
+	TArray<TSubclassOf<UActorIORegisterBase>> ActorIORegisters;
 
 public:
 
@@ -76,6 +81,12 @@ public:
 	UFUNCTION(BlueprintImplementableEvent, Category = "Actor IO", DisplayName = "Get Global Named Arguments", meta = (ForceAsFunction, Keywords = "IO"))
 	void K2_GetGlobalNamedArguments();
 
+	/** Exposes events to the I/O system by actor I/O registers. */
+	void GetObjectEventsFromIORegisters(AActor* InObject, FActorIOEventList& EventRegistry);
+
+	/** Exposes functions to the I/O system by actor I/O registers. */
+	void GetObjectFunctionsFromIORegisters(AActor* InObject, FActorIOFunctionList& FunctionRegistry);
+
 private:
 
 	/** Event processor for the 'OnActorBeginOverlap' and 'OnActorEndOverlap' events. */
@@ -89,6 +100,7 @@ private:
 public:
 
 	//~ Begin UWorldSubsystem Interface
+	virtual void PostInitialize() override;
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override final;
 	//~ End UWorldSubsystem Interface
 };


### PR DESCRIPTION
For some types, especially engine built-in classes, registering ActorIO system events and functions is difficult and cumbersome, and most of them need to inherit a separate subclass and implement the IO interface to do so. This new approach allows users to create custom registration classes on the blueprint side and register events and functions to any Actor type.

And for ease of use on the blueprint side, I chose UObject as the registration class instead of Instanced Struct.

The registered class can specify a target class, and when registering subclasses of that class, it will additionally get registered events and functions from the registered class, similar to GetNativeEventsForObject().

Engine internal classes that were originally registered using hard-coded registration can also be refactored using this new registration method, making them easier to maintain in the long run.

For now, I've kept the original registration method and added the new method as a new feature, if the feature is adopted, a larger refactoring can be considered.